### PR TITLE
what's app widget is showing over the preloader

### DIFF
--- a/static/css/preloader.css
+++ b/static/css/preloader.css
@@ -94,3 +94,7 @@
     align-items: center;
     justify-content: center;
   }
+  .cVijEW
+  {
+    z-index: 10 !important;
+  }


### PR DESCRIPTION
what's app widget is showing over the preloader

Fixes : #381 