### PR TITLE
Signup buttons enhancement

### DIFF
--- a/static/css/form.css
+++ b/static/css/form.css
@@ -142,3 +142,6 @@ button:hover{
 	color: #fff !important;
 	margin:5px !important;
 }
+.btn-font {
+	color: #fff;
+}

--- a/template/login_new.html
+++ b/template/login_new.html
@@ -25,8 +25,8 @@
 			</div>
 		</form>
 		
-    	<button class="google"><i class="fab fa-google"></i> <a href="{% provider_login_url 'google' %}">sign in with Google</a></button>
-		<button class="facebook"><i class="fab fa-facebook-f"></i><a href="{% provider_login_url 'facebook' method='oauth2' %}">sign in with Facebook</a></button>
+    	<button class="google"><i class="fab fa-google"></i> <a class="btn-font" href="{% provider_login_url 'google' %}">sign in with Google</a></button>
+		<button class="facebook"><i class="fab fa-facebook-f"></i> <a class="btn-font" href="{% provider_login_url 'facebook' method='oauth2' %}">sign in with Facebook</a></button>
 	</div>
 	<script>
 				// for show password for one


### PR DESCRIPTION
## Related Issue 

- Info about the related issue 
Closes: #397 
Sign In buttons, like Google and Facebook had very dark labels, which makes the text unreadable.
<img width="550" alt="old" src="https://user-images.githubusercontent.com/63901956/131072827-6b3f5144-5688-4c60-aa09-f070989c24ce.png">


### Describe the changes you've made
As a UI/UX Designer, the website is well versed with the best UI Design but there is very small pin point in the Sign Up buttons, where the text label on the button hides the visibility and readability. So, I have changed the font-color of the SignUp Buttons.

<img width="550" alt="new" src="https://user-images.githubusercontent.com/63901956/131072929-6a432fba-2f20-40d8-abe1-aa7b9e64be83.png">


## Type of change

What sort of change have you made:
<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Mention any unusual behaviour of your code (Write NA if not)
NA

## Additional Info (optional)
I have changed two files:
- modified:   static/css/form.css
<img width="400" alt="ui_new" src="https://user-images.githubusercontent.com/63901956/131073265-a706188f-de0e-4f1f-8c7a-cad5b7579943.png">
- modified:   template/login_new.html
<img width="400" alt="ui_new_2" src="https://user-images.githubusercontent.com/63901956/131073278-9688cc5e-de45-4780-90d7-84d62f5dfae4.png">


## Checklist:
<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x] My code follows the guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly wherever it was hard to understand.
- [x] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.

